### PR TITLE
Fix invalid condition, so packer ignores other atrules (@font-face, @page)

### DIFF
--- a/lib/css-mqpacker.js
+++ b/lib/css-mqpacker.js
@@ -7,7 +7,7 @@ var _process = function (css) {
   var queries = {};
 
   css.each(function (rule, i) {
-    if (rule.type !== 'atrule' && rule.name !== 'media') {
+    if (rule.type !== 'atrule' || rule.name !== 'media') {
       return true;
     }
 

--- a/test/expected/simple.css
+++ b/test/expected/simple.css
@@ -4,6 +4,16 @@
   z-index: 1;
 }
 
+@font-face {
+  font-family: 'family';
+  src: 'family.eot';
+}
+
+@font-face {
+  font-family: 'family';
+  src: 'family.woff';
+}
+
 .bar {
   z-index: 2;
 }

--- a/test/fixtures/simple.css
+++ b/test/fixtures/simple.css
@@ -4,6 +4,16 @@
   z-index: 1;
 }
 
+@font-face {
+  font-family: 'family';
+  src: 'family.eot';
+}
+
+@font-face {
+  font-family: 'family';
+  src: 'family.woff';
+}
+
 @media (min-width: 999px) {
   .foo {
     z-index: 4;


### PR DESCRIPTION
`@page`, `@font-face` and `@keyframes` were parsed as media query and easily caused problems (added test case for this).

This PR fixes invalid condition which determines whether current rule should be packed or not.
