### PR TITLE
Replace e.removeSelf() with parent.remove(e)

### DIFF
--- a/lib/css-mqpacker.js
+++ b/lib/css-mqpacker.js
@@ -16,7 +16,9 @@ var _process = function (css) {
     var past = queries[query];
 
     if (typeof past === 'object') {
-      rule.first.before = past.parent.after + rule.first.before;
+      if (past.parent.after !== undefined) {
+        rule.first.before = past.parent.after + rule.first.before;
+      }
       rule.each(function (r) {
         past.append(r);
       });
@@ -25,7 +27,7 @@ var _process = function (css) {
       params.push(query);
     }
 
-    css.remove(rule);
+    rule.removeSelf();
   });
 
   params.forEach(function (param) {


### PR DESCRIPTION
I've seen very strange problems with the `removeSelf()` method. It seems that the function do this job but the final CSS still have rules. Using `css.remove(rule)` works every time as expected. More details here: https://github.com/ai/postcss/issues/48
