### PR TITLE
Sort media queries

### DIFF
--- a/lib/css-mqpacker.js
+++ b/lib/css-mqpacker.js
@@ -4,7 +4,6 @@ var postcss = require('postcss');
 
 exports.postcss = function (css) {
   var queries = {};
-  var params = [];
   var sourceMap;
 
   css.each(function (rule) {
@@ -21,7 +20,6 @@ exports.postcss = function (css) {
       });
     } else {
       queries[query] = rule.clone();
-      params.push(query);
     }
 
     rule.removeSelf();
@@ -35,8 +33,10 @@ exports.postcss = function (css) {
     sourceMap = css.last;
   }
 
-  params.forEach(function (param) {
-    css.append(queries[param]);
+  queries = sortQueries(queries);
+
+  queries.forEach(function (rule) {
+    css.append(rule);
   });
 
   if (sourceMap) {
@@ -48,4 +48,103 @@ exports.postcss = function (css) {
 
 exports.pack = function (css, opts) {
   return postcss().use(this.postcss).process(css, opts);
+};
+
+/**
+ * Sort media queries by kind, this is needed to output them in the right order
+ * @param {AtRule[]} queries
+ *
+ * Function code from https://github.com/buildingblocks/grunt-combine-media-queries
+ */
+var sortQueries = function (queries) {
+  var byType = {};
+  byType.all = [];
+  byType.minWidth = [];
+  byType.maxWidth = [];
+  byType.minHeight = [];
+  byType.maxHeight = [];
+  byType.print = [];
+  byType.blank = [];
+
+  Object.keys(queries).forEach(function (key) {
+    /** @type AtRule */
+    var item = queries[key];
+    if (key.match(/min-width/)) {
+      byType.minWidth.push(item);
+    }
+    else if (key.match(/min-height/)) {
+      byType.minHeight.push(item);
+    }
+    else if (key.match(/max-width/)) {
+      byType.maxWidth.push(item);
+    }
+    else if (key.match(/max-height/)) {
+      byType.maxHeight.push(item);
+    }
+    else if (key.match(/print/)) {
+      byType.print.push(item);
+    }
+    else if (key.match(/all/)) {
+      byType.all.push(item);
+    }
+    else {
+      byType.blank.push(item);
+    }
+  });
+  /**
+   * Function to determine sort order
+   * @param {AtRule} a
+   * @param {AtRule} b
+   * @param {boolean} isMax
+   * @returns {number}
+   */
+  var determineSortOrder = function (a, b, isMax) {
+    var sortValA = parseFloat(a.params.match(/\d+/g)),
+      sortValB = parseFloat(b.params.match(/\d+/g));
+    isMax = typeof isMax !== 'undefined' ? isMax : false;
+    // consider print for sorting if sortVals are equal
+    if (sortValA === sortValB) {
+      if (a.params.match(/print/)) {
+        // a contains print and should be sorted after b
+        return 1;
+      }
+      if (b.params.match(/print/)) {
+        // b contains print and should be sorted after a
+        return -1;
+      }
+    }
+    // return descending sort order for max-(width|height) media queries
+    if (isMax) {
+      return sortValB - sortValA;
+    }
+    // return ascending sort order
+    return sortValA - sortValB;
+  };
+  // Sort queries ascending
+  byType.all.sort(determineSortOrder);
+  byType.minWidth.sort(determineSortOrder);
+  byType.minHeight.sort(determineSortOrder);
+  // Sort queries descending
+  byType.maxWidth.sort(function (a, b) {
+    return determineSortOrder(a, b, true);
+  });
+  byType.maxHeight.sort(function (a, b) {
+    return determineSortOrder(a, b, true);
+  });
+
+  var sortedTypes = [
+    byType.blank,
+    byType.all,
+    byType.minWidth,
+    byType.minHeight,
+    byType.maxWidth,
+    byType.maxHeight,
+    byType.print
+  ];
+  return sortedTypes.reduce(
+    function (previousValue, currentValue) {
+      return previousValue.concat(currentValue);
+    },
+    []
+  );
 };

--- a/test/expected/sort-queries.css
+++ b/test/expected/sort-queries.css
@@ -1,0 +1,112 @@
+.test {
+    color: red;
+}
+@media screen {
+    .test {
+        color: red;
+    }
+}
+@media only screen {
+    .test {
+        color: red;
+    }
+}
+@media all {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (min-width: 28em) {
+    .test {
+        color: red;
+    }
+}
+@media (min-width: 28em) {
+    .test {
+        color: red;
+    }
+}
+@media print, only screen and (min-width: 28em) {
+    .test {
+        color: red;
+    }
+}
+@media (min-width: 46em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (min-width: 46em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (min-width: 46em) and (max-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media print, only screen and (min-width: 46em) and (max-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media print, only screen and (min-width: 46em) {
+    .test {
+        color: red;
+    }
+}
+@media (min-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (min-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media print, only screen and (min-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (max-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media print, only screen and (max-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (max-width: 45em) {
+    .test {
+        color: red;
+    }
+}
+@media (max-width: 45em) {
+    .test {
+        color: red;
+    }
+}
+@media print {
+    .test {
+        color: red;
+    }
+    .test {
+        color: red;
+    }
+    .test {
+        color: red;
+    }
+    .test {
+        color: red;
+    }
+}
+@media only print {
+    .test {
+        color: red;
+    }
+}

--- a/test/fixtures/sort-queries.css
+++ b/test/fixtures/sort-queries.css
@@ -1,0 +1,118 @@
+@media print, only screen and (min-width: 28em) {
+    .test {
+        color: red;
+    }
+}
+@media print, only screen and (min-width: 46em) {
+    .test {
+        color: red;
+    }
+}
+@media print, only screen and (min-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media print, only screen and (max-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (max-width: 45em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (min-width: 28em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (min-width: 46em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (min-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (max-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media print {
+    .test {
+        color: red;
+    }
+}
+@media screen {
+    .test {
+        color: red;
+    }
+}
+@media all {
+    .test {
+        color: red;
+    }
+}
+@media print, only screen and (min-width: 46em) and (max-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen and (min-width: 46em) and (max-width: 61em) {
+    .test {
+        color: red;
+    }
+}
+@media only screen {
+    .test {
+        color: red;
+    }
+}
+@media only print {
+    .test {
+        color: red;
+    }
+}
+@media print {
+    .test {
+        color: red;
+    }
+}
+@media print {
+    .test {
+        color: red;
+    }
+}
+@media print {
+    .test {
+        color: red;
+    }
+}
+.test {
+    color: red;
+}
+@media (max-width: 45em) {
+    .test {
+        color: red;
+    }
+}
+@media (min-width: 28em) {
+    .test {
+        color: red;
+    }
+}
+@media (min-width: 46em) {
+    .test {
+        color: red;
+    }
+}
+@media (min-width: 61em) {
+    .test {
+        color: red;
+    }
+}


### PR DESCRIPTION
Note: Function code from https://github.com/buildingblocks/grunt-combine-media-queries

* Why this feature should be merged even breaking the backward compatibility?

Following the idea there is not "unsafe group" only bad CSS code (https://github.com/hail2u/node-css-mqpacker/issues/16#issuecomment-53139026) I have ported this sort algorithm from https://github.com/buildingblocks/grunt-combine-media-queries

* Where MQpacker fail and really is a fail in the library?

MQPacker fail because "have" a first win algoritm. So the result CSS has the same order of media queries as found in the original source.

But what happens in the following scenario?

```css
/* From WidgetA.less */
.widgetA: { foo: 'xxx' }
@media (min-width:1024px) {
 .widgetA: {'foo': 'yyy'}
}

/* From WidgetB.less */
.widgetB: { foo: 'xxx' }
@media (min-width:480px) {
 .widgetB: {'foo': 'yyy'}
}
@media (min-width:1024px) {
 .widgetB: {'foo': 'zzz'}
}
```

Both widgets are well written CSS individually and have the media queries sorted.
But after process the CSS we have the following result:

```css
.widgetA: { foo: 'xxx' }
.widgetB: { foo: 'xxx' }
@media (min-width:1024px) {
 .widgetA: {'foo': 'yyy'}
 .widgetB: {'foo': 'zzz'}   // OOOps this now have lower priority!!!.
}
@media (min-width:480px) {
 .widgetB: {'foo': 'yyy'}
}
```

So this PR fix this situation **enforcing** to use a specific sorted algoritm. CSS programers **MUST** follow this algoritm if they want to have a working CSS file after use MQpacker

The result is:
```css
.widgetA: { foo: 'xxx' }
.widgetB: { foo: 'xxx' }
@media (min-width:480px) {
 .widgetB: {'foo': 'yyy'}
}
@media (min-width:1024px) {
 .widgetA: {'foo': 'yyy'}
 .widgetB: {'foo': 'zzz'}
}
```

The algoritm used here is the same used at https://github.com/buildingblocks/grunt-combine-media-queries (MIT license)

These are the rules applied:

1. Rules without media queries.
2. min-width rules sorted in ascending order by width value.
3. print media and min-width rules sorted in ascending order by width value.
4. min-height rules sorted in ascending order by height value.
5. print media and min-height rules sorted in ascending order by height value.
6. max-width rules sorted in descending order by width value.
7. print media and max-width rules sorted in descending order by width value.
8. max-height rules sorted in descending order by height value.
9. print media and max-height rules sorted in descending order by height value.
10. Rest of print media queries

