### PR TITLE
[WIP] Sort `min-width` queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,39 @@ You will get following output:
 Sweet!
 
 
+OPTIONS
+-------
+
+### sort
+
+By default, CSS MQPacker pack and order media queries as they are defined. See
+also [The "First Win" Algorithm][2]. If you want sort queries automatically,
+pass `sort: true` to this module.
+
+```javascript
+mqpacker({
+  sort: true
+}).pack(css);
+```
+
+Currently, this option only supports `min-width` queries. If you want to do
+more, you need to create your own sorting function and pass it to this option
+like this:
+
+```javascript
+mqpacker({
+  sort: function (a, b) {
+    return a.localeCompare(b);
+  }
+}).pack(css);
+```
+
+In this example, all your queries will sort by A-Z order.
+
+This sorting function directly pass to `Array#sort()` method of an array of all
+your queries.
+
+
 API
 ---
 
@@ -174,7 +207,8 @@ To pack `src/css/**/*.css` to `build/css/**/*.min.css` with source map:
       }
     });
 
-The `options` is completely same as [this package options][6].
+You can specify both [options of this package][7] and [PostCSS options][3] with
+`options` field of this task.
 
 
 KNOWN ISSUE
@@ -305,8 +339,9 @@ MIT: http://hail2u.mit-license.org/2014
 
 
 [1]: https://github.com/postcss/postcss
-[2]: https://github.com/postcss/postcss#source-map-1
-[3]: https://github.com/postcss/postcss#processor
-[4]: https://github.com/postcss/autoprefixer-core
-[5]: https://github.com/nDmitry/grunt-postcss
-[6]: #packcss-options
+[2]: #the-first-win-algorithm
+[3]: https://github.com/postcss/postcss#source-map-1
+[4]: https://github.com/postcss/postcss#processor
+[5]: https://github.com/postcss/autoprefixer-core
+[6]: https://github.com/nDmitry/grunt-postcss
+[7]: #options

--- a/lib/css-mqpacker.js
+++ b/lib/css-mqpacker.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var cssMQPacker;
+
+var list = require('postcss/lib/list');
 var postcss = require('postcss');
 
 var hasSourceMapAnnotation = function (css) {
@@ -18,7 +21,158 @@ var hasSourceMapAnnotation = function (css) {
   return true;
 };
 
-exports.postcss = function (css) {
+var parseQueryList = function (queryList) {
+  var queries = [];
+  list.comma(queryList).forEach(function (query) {
+    var expressions = {};
+    list.space(query).forEach(function (expression) {
+      var feature;
+      var value;
+      expression = expression.toLowerCase();
+
+      if (expression === 'and') {
+        return;
+      }
+
+      if (/^\w+$/.test(expression)) {
+        expressions[expression] = true;
+
+        return;
+      }
+
+      expression = list.split(expression.replace(/^\(|\)$/g, ''), [':']);
+
+      if (expression.length < 1) {
+        return;
+      }
+
+      feature = expression[0];
+      value = expression[1];
+
+      if (!expressions[feature]) {
+        expressions[feature] = [];
+      }
+
+      expressions[feature].push(value);
+    });
+    queries.push(expressions);
+  });
+
+  return queries;
+};
+
+var inspectLength = function (length) {
+  var num;
+  var unit;
+  length = /(-?\d*\.?\d+)(ch|em|ex|pc|px|pt|rem)/.exec(length);
+
+  if (!length) {
+    return Number.MAX_VALUE;
+  }
+
+  num = length[1];
+  unit = length[2];
+
+  switch (unit) {
+    case 'ch': {
+      num = parseFloat(num) * 8.8984375;
+
+      break;
+    }
+
+    case 'em':
+    case 'rem': {
+      num = parseFloat(num) * 16;
+
+      break;
+    }
+
+    case 'ex': {
+      num = parseFloat(num) * 8.296875;
+
+      break;
+    }
+
+    case 'pc': {
+      num = parseFloat(num) * 12 / 3 * 4;
+
+      break;
+    }
+
+    case 'pt': {
+      num = parseFloat(num) / 3 * 4;
+
+      break;
+    }
+
+    case 'px': {
+      num = parseFloat(num);
+
+      break;
+    }
+  }
+
+  return num;
+};
+
+var pickMinimumMinWidth = function (expressions) {
+  var minWidths = [];
+  expressions.forEach(function (feature) {
+    var minWidth = feature['min-width'];
+
+    if (!minWidth || feature.not || feature.print) {
+      minWidth = [null];
+    }
+
+    minWidths.push(minWidth.map(inspectLength).sort(function (a, b) {
+      return b - a;
+    })[0]);
+  });
+
+  return minWidths.sort(function (a, b) {
+    return a - b;
+  })[0];
+};
+
+var sortQueryLists = function (queryLists, sort) {
+  var mapQueryLists = [];
+
+  if (!sort) {
+    return queryLists;
+  }
+
+  if (typeof sort === 'function') {
+    return queryLists.sort(sort);
+  }
+
+  queryLists.forEach(function (queryList) {
+    mapQueryLists.push(parseQueryList(queryList));
+  });
+
+  return mapQueryLists.map(function (e, i) {
+    return {
+      index: i,
+      value: pickMinimumMinWidth(e)
+    };
+  }).sort(function (a, b) {
+    return a.value - b.value;
+  }).map(function (e) {
+    return queryLists[e.index];
+  });
+};
+
+// CSSMQPacker object
+var CSSMQPacker = function (opts) {
+  var sort = false;
+
+  if (opts && opts.sort) {
+    sort = opts.sort;
+  }
+
+  this.postcss = this.postcss.bind(null, sort);
+};
+
+CSSMQPacker.prototype.postcss = function (sort, css) {
   var queries = {};
   var queryLists = [];
   var sourceMap;
@@ -44,7 +198,7 @@ exports.postcss = function (css) {
     atRule.removeSelf();
   });
 
-  queryLists.forEach(function (queryList) {
+  sortQueryLists(queryLists, sort).forEach(function (queryList) {
     css.append(queries[queryList]);
   });
 
@@ -55,6 +209,21 @@ exports.postcss = function (css) {
   return css;
 };
 
-exports.pack = function (css, opts) {
+CSSMQPacker.prototype.pack = function (css, opts) {
   return postcss().use(this.postcss).process(css, opts);
 };
+
+// cssMQPacker instance
+cssMQPacker = function (opts) {
+  return new CSSMQPacker(opts);
+};
+
+cssMQPacker.postcss = function (css) {
+  return cssMQPacker().postcss(css);
+};
+
+cssMQPacker.pack = function (css, opts) {
+  return cssMQPacker(opts).pack(css, opts);
+};
+
+module.exports = cssMQPacker;

--- a/tasks/css_mqpacker.js
+++ b/tasks/css_mqpacker.js
@@ -34,7 +34,7 @@ module.exports = function (grunt) {
         options.to = dest;
       }
 
-      processed = mqpacker.pack(fs.readFileSync(src, 'utf8'), options);
+      processed = mqpacker(options).pack(fs.readFileSync(src, 'utf8'), options);
       fs.outputFileSync(dest, processed.css);
       grunt.log.writeln('File "' + dest + '" created.');
 

--- a/test/css-mqpacker_test.js
+++ b/test/css-mqpacker_test.js
@@ -11,7 +11,7 @@ exports['Public API'] = function (test) {
   var input = '@media (min-width:1px) {\n    .foo {\n        color: black\n    }\n}';
   expected = postcss().process(input).css;
 
-  test.expect(2);
+  test.expect(4);
 
   test.strictEqual(
     mqpacker.pack(input).css,
@@ -19,7 +19,17 @@ exports['Public API'] = function (test) {
   );
 
   test.strictEqual(
+    mqpacker().pack(input).css,
+    expected
+  );
+
+  test.strictEqual(
     postcss().use(mqpacker.postcss).process(input).css,
+    expected
+  );
+
+  test.strictEqual(
+    postcss().use(mqpacker().postcss).process(input).css,
     expected
   );
 
@@ -53,6 +63,50 @@ exports['Option: PostCSS options'] = function (test) {
   test.done();
 };
 
+exports['Option: sort'] = function (test) {
+  var a;
+  var b = mqpacker();
+  var expected = '@media (min-width: 1px) {\n    .foo {\n        z-index: 1\n    }\n}\n@media (min-width: 2px) {\n    .foo {\n        z-index: 2\n    }\n}';
+  var input = '@media (min-width: 2px) { .foo { z-index: 2 } }@media (min-width: 1px) { .foo { z-index: 1 } }';
+  var opts = {
+    sort: true
+  };
+  a = mqpacker(opts);
+
+  test.expect(5);
+
+  test.notStrictEqual(
+    mqpacker.pack(input).css,
+    expected
+  );
+
+  test.strictEqual(
+    mqpacker(opts).pack(input).css,
+    expected
+  );
+
+  test.strictEqual(
+    mqpacker.pack(input, opts).css,
+    expected
+  );
+
+  test.notStrictEqual(
+    postcss().use(a.postcss).process(input).css,
+    postcss().use(b.postcss).process(input).css
+  );
+
+  test.strictEqual(
+    mqpacker({
+      sort: function (c, d) {
+        return c.localeCompare(d);
+      }
+    }).pack(input).css,
+    expected
+  );
+
+  test.done();
+};
+
 exports['Real CSS'] = function (test) {
   var testCases = fs.readdirSync(path.join(__dirname, 'fixtures'));
 
@@ -71,8 +125,16 @@ exports['Real CSS'] = function (test) {
   test.expect(testCases.length);
 
   testCases.forEach(function (testCase) {
+    var opts = {
+      sort: false
+    };
+
+    if (testCase.indexOf('sort_') === 0) {
+      opts.sort = true;
+    }
+
     test.strictEqual(
-      mqpacker.pack(loadInput(testCase)).css,
+      mqpacker.pack(loadInput(testCase), opts).css,
       loadExpected(testCase),
       testCase
     );

--- a/test/expected/sort_different-units.css
+++ b/test/expected/sort_different-units.css
@@ -1,0 +1,35 @@
+@media (min-width: 16px) {
+    .foo {
+        z-index: 1
+    }
+}
+@media (min-width: 1.0625em) {
+    .foo {
+        z-index: 2
+    }
+}
+@media (min-width: 1.125rem) {
+    .foo {
+        z-index: 3
+    }
+}
+@media (min-width: 2.29ex) {
+    .foo {
+        z-index: 4
+    }
+}
+@media (min-width: 2.248ch) {
+    .foo {
+        z-index: 5
+    }
+}
+@media (min-width: 15.75pt) {
+    .foo {
+        z-index: 6
+    }
+}
+@media (min-width: 1.375pc) {
+    .foo {
+        z-index: 7
+    }
+}

--- a/test/expected/sort_duplicate-queries.css
+++ b/test/expected/sort_duplicate-queries.css
@@ -1,0 +1,15 @@
+@media (min-width: 3em) and (min-width: 4em) {
+    .foo {
+        z-index: 1
+    }
+}
+@media (min-width: 2em) and (min-width: 5em) {
+    .foo {
+        z-index: 2
+    }
+}
+@media (min-width: 1em) and (min-width: 6em) {
+    .foo {
+        z-index: 3
+    }
+}

--- a/test/expected/sort_ignore-not-queries.css
+++ b/test/expected/sort_ignore-not-queries.css
@@ -1,0 +1,20 @@
+@media (min-width: 1em) {
+    .foo {
+        z-index: 1
+    }
+}
+@media (min-width: 2em) {
+    .foo {
+        z-index: 2
+    }
+}
+@media not screen, (min-width: 3em) {
+    .foo {
+        z-index: 3
+    }
+}
+@media not (min-width: 1em) {
+    .foo {
+        z-index: 4
+    }
+}

--- a/test/expected/sort_ignore-other-queries.css
+++ b/test/expected/sort_ignore-other-queries.css
@@ -1,0 +1,15 @@
+@media (min-width: 1em) and (min-height: 1em) {
+    .foo {
+        z-index: 1
+    }
+}
+@media screen and (min-width: 2em) {
+    .foo {
+        z-index: 2
+    }
+}
+@media all, (min-width: 3em) {
+    .foo {
+        z-index: 3
+    }
+}

--- a/test/expected/sort_ignore-print-queries.css
+++ b/test/expected/sort_ignore-print-queries.css
@@ -1,0 +1,20 @@
+@media (min-width: 1em) {
+    .foo {
+        z-index: 1
+    }
+}
+@media (min-width: 2em) {
+    .foo {
+        z-index: 2
+    }
+}
+@media print, (min-width: 3em) {
+    .foo {
+        z-index: 3
+    }
+}
+@media print and (min-width: 1em) {
+    .foo {
+        z-index: 4
+    }
+}

--- a/test/expected/sort_queries.css
+++ b/test/expected/sort_queries.css
@@ -1,0 +1,30 @@
+@media (min-width: 1em) {
+    .foo {
+        z-index: 1
+    }
+}
+@media (min-width: 2em) {
+    .foo {
+        z-index: 2
+    }
+}
+@media (min-width: 3em) {
+    .foo {
+        z-index: 3
+    }
+}
+@media (min-width: 4em) {
+    .foo {
+        z-index: 4
+    }
+}
+@media (min-width: 5em) {
+    .foo {
+        z-index: 5
+    }
+}
+@media (min-width: 6em) {
+    .foo {
+        z-index: 6
+    }
+}

--- a/test/expected/sort_skip-non-min-width-queries.css
+++ b/test/expected/sort_skip-non-min-width-queries.css
@@ -1,0 +1,20 @@
+@media (min-width: 1em) {
+    .foo {
+        z-index: 1
+    }
+}
+@media (min-width: 2em) {
+    .foo {
+        z-index: 2
+    }
+}
+@media (min-resolution: 1dppx) {
+    .foo {
+        z-index: 3
+    }
+}
+@media tv {
+    .foo {
+        z-index: 4
+    }
+}

--- a/test/fixtures/sort_different-units.css
+++ b/test/fixtures/sort_different-units.css
@@ -1,0 +1,41 @@
+@media (min-width: 2.248ch) {
+  .foo {
+    z-index: 5
+  }
+}
+
+@media (min-width: 1.375pc) {
+  .foo {
+    z-index: 7;
+  }
+}
+
+@media (min-width: 1.125rem) {
+  .foo {
+    z-index: 3;
+  }
+}
+
+@media (min-width: 2.29ex) {
+  .foo {
+    z-index: 4;
+  }
+}
+
+@media (min-width: 15.75pt) {
+  .foo {
+    z-index: 6;
+  }
+}
+
+@media (min-width: 1.0625em) {
+  .foo {
+    z-index: 2;
+  }
+}
+
+@media (min-width: 16px) {
+  .foo {
+    z-index: 1;
+  }
+}

--- a/test/fixtures/sort_duplicate-queries.css
+++ b/test/fixtures/sort_duplicate-queries.css
@@ -1,0 +1,17 @@
+@media (min-width: 1em) and (min-width: 6em) {
+  .foo {
+    z-index: 3;
+  }
+}
+
+@media (min-width: 2em) and (min-width: 5em) {
+  .foo {
+    z-index: 2;
+  }
+}
+
+@media (min-width: 3em) and (min-width: 4em) {
+  .foo {
+    z-index: 1;
+  }
+}

--- a/test/fixtures/sort_ignore-not-queries.css
+++ b/test/fixtures/sort_ignore-not-queries.css
@@ -1,0 +1,23 @@
+@media (min-width: 2em) {
+  .foo {
+    z-index: 2;
+  }
+}
+
+@media not (min-width: 1em) {
+  .foo {
+    z-index: 4;
+  }
+}
+
+@media not screen, (min-width: 3em) {
+  .foo {
+    z-index: 3;
+  }
+}
+
+@media (min-width: 1em) {
+  .foo {
+    z-index: 1;
+  }
+}

--- a/test/fixtures/sort_ignore-other-queries.css
+++ b/test/fixtures/sort_ignore-other-queries.css
@@ -1,0 +1,17 @@
+@media screen and (min-width: 2em) {
+  .foo {
+    z-index: 2;
+  }
+}
+
+@media all, (min-width: 3em) {
+  .foo {
+    z-index: 3;
+  }
+}
+
+@media (min-width: 1em) and (min-height: 1em) {
+  .foo {
+    z-index: 1;
+  }
+}

--- a/test/fixtures/sort_ignore-print-queries.css
+++ b/test/fixtures/sort_ignore-print-queries.css
@@ -1,0 +1,23 @@
+@media (min-width: 2em) {
+  .foo {
+    z-index: 2;
+  }
+}
+
+@media print and (min-width: 1em) {
+  .foo {
+    z-index: 4;
+  }
+}
+
+@media print, (min-width: 3em) {
+  .foo {
+    z-index: 3;
+  }
+}
+
+@media (min-width: 1em) {
+  .foo {
+    z-index: 1;
+  }
+}

--- a/test/fixtures/sort_queries.css
+++ b/test/fixtures/sort_queries.css
@@ -1,0 +1,35 @@
+@media (min-width: 3em) {
+  .foo {
+    z-index: 3;
+  }
+}
+
+@media (min-width: 2em) {
+  .foo {
+    z-index: 2;
+  }
+}
+
+@media (min-width: 1em) {
+  .foo {
+    z-index: 1;
+  }
+}
+
+@media (min-width: 6em) {
+  .foo {
+    z-index: 6;
+  }
+}
+
+@media (min-width: 4em) {
+  .foo {
+    z-index: 4;
+  }
+}
+
+@media (min-width: 5em) {
+  .foo {
+    z-index: 5;
+  }
+}

--- a/test/fixtures/sort_skip-non-min-width-queries.css
+++ b/test/fixtures/sort_skip-non-min-width-queries.css
@@ -1,0 +1,23 @@
+@media (min-width: 2em) {
+  .foo {
+    z-index: 2;
+  }
+}
+
+@media (min-resolution: 1dppx) {
+  .foo {
+    z-index: 3;
+  }
+}
+
+@media (min-width: 1em) {
+  .foo {
+    z-index: 1;
+  }
+}
+
+@media tv {
+  .foo {
+    z-index: 4;
+  }
+}


### PR DESCRIPTION
This will fix part of issue #16.

- [x] Implement as opt-in features
- [x] Basic sorting
- [x] Unit conversion
    - [x] `ch`
    - [x] `em`
    - [x] `ex`
    - [x] `pc`
    - [x] `pt`
    - [x] `rem`
    - [x] Ignore `calc()`
    - [x] Ignore other units
- [x] Support sorting if it has unsupported queries between them
    - [x] <del>Append</del> Prepend sorted `min-width` queries
- [x] `not` keyword
- [x] Skip `print`
- [x] Documentation
- [x] Code clean up