### PR TITLE
Deleting test files from the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "index.js",
     "lib",
     "package.json",
-    "tasks",
-    "test"
+    "tasks"
   ],
   "homepage": "https://github.com/hail2u/node-css-mqpacker",
   "keywords": [


### PR DESCRIPTION
Excludes unnecessary files from redist package. The average user does not need tests in the package. They need developers.