### PR TITLE
Process only direct child of root

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,10 @@ module.exports = postcss.plugin(pkg.name, (opts) => {
     }
 
     css.walkAtRules("media", (atRule) => {
+      if (atRule.parent.type !== "root") {
+        return;
+      }
+
       const queryList = atRule.params;
       const past = queries[queryList];
 

--- a/test/expected/issue50.css
+++ b/test/expected/issue50.css
@@ -1,0 +1,21 @@
+.foo {
+  z-index: 1;
+}
+
+@supports (display: auto) {
+  .foo {
+    z-index: 2;
+  }
+
+  @media (min-width: 1024px) {
+    .foo {
+      z-index: 3;
+    }
+  }
+}
+
+@media (min-width: 1024px) {
+  .foo {
+    z-index: 4;
+  }
+}

--- a/test/fixtures/issue50.css
+++ b/test/fixtures/issue50.css
@@ -1,0 +1,21 @@
+.foo {
+  z-index: 1;
+}
+
+@media (min-width: 1024px) {
+  .foo {
+    z-index: 4;
+  }
+}
+
+@supports (display: auto) {
+  .foo {
+    z-index: 2;
+  }
+
+  @media (min-width: 1024px) {
+    .foo {
+      z-index: 3;
+    }
+  }
+}


### PR DESCRIPTION
`supports` can have a `media`. We should not break this nested
structure, so keep nested `media` as it is.

This fixes #50.