### PR TITLE
Treat 0 as correct CSS length

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ function parseQueryList(queryList) {
 }
 
 function inspectLength(length) {
+  if (length === "0") {
+    return 0;
+  }
+
   length = /(-?\d*\.?\d+)(ch|em|ex|px|rem)/.exec(length);
 
   if (!length) {

--- a/test/expected/sort_zero.css
+++ b/test/expected/sort_zero.css
@@ -1,0 +1,21 @@
+.foo {
+  z-index: 0;
+}
+
+@media (min-width: 0) {
+  .foo {
+    z-index: 1;
+  }
+}
+
+@media (min-width: 9px) {
+  .foo {
+    z-index: 2;
+  }
+}
+
+@media (min-width: 99px) {
+  .foo {
+    z-index: 3;
+  }
+}

--- a/test/fixtures/sort_zero.css
+++ b/test/fixtures/sort_zero.css
@@ -1,0 +1,21 @@
+.foo {
+  z-index: 0;
+}
+
+@media (min-width: 99px) {
+  .foo {
+    z-index: 3;
+  }
+}
+
+@media (min-width: 0) {
+  .foo {
+    z-index: 1;
+  }
+}
+
+@media (min-width: 9px) {
+  .foo {
+    z-index: 2;
+  }
+}


### PR DESCRIPTION
`(min-width: 0)` is parsed and picked up correctly, but was inspected
as a invalid CSS length whereas 0 is a valid CSS length. MQPacker should
special-case `0` (only `0`).

This fixed #57.