### PR TITLE
Add TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,24 @@
+import type {
+    Plugin,
+    ProcessOptions,
+    Processor
+} from 'postcss';
+
+export interface Options {
+    readonly sort?: boolean;
+}
+
+export interface Packer {
+    (options?: Options): Plugin;
+
+    pack(
+        css: string,
+        opts?: Options & ProcessOptions
+    ): ReturnType<Processor['process']>;
+
+    readonly postcss: true;
+}
+
+declare const mqpacker: Packer;
+
+export default mqpacker;

--- a/package.json
+++ b/package.json
@@ -8,8 +8,13 @@
 	},
 	"license": "MIT",
 	"author": "Kyo Nagashima <hail2u@gmail.com> (https://hail2u.net/)",
-	"files": [],
+	"files": [
+		"bin",
+		"index.js",
+		"index.d.ts"
+	],
 	"main": "index.js",
+	"types": "index.d.ts",
 	"bin": {
 		"mqpacker": "./bin/mqpacker.js"
 	},


### PR DESCRIPTION
Add TypeScript definitions for people consuming this in a TypeScript setting - e.g. a `webpack.config.ts`, or a `vite.config.ts` (as is my case). 

Requires us to explicitly define the `files` in `package.json` as a result, as otherwise the `index.d.ts` file would not be picked up. 

I've ensured that both the `bin` dir and the `index.js` still get shipped by double checking with `npm pack`.